### PR TITLE
Add config support for headers to be included

### DIFF
--- a/config/alt-redirect.php
+++ b/config/alt-redirect.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Headers
+    |--------------------------------------------------------------------------
+    |
+    | A key/value pair of Headers to be included with the redirect. This
+    | applies to all redirects. For example:
+    |
+    | 'headers' => [
+    |     'Cache-Control' => 'no-cache, must-revalidate',
+    | ];
+    |
+    */
+
+    'headers' => []
+
+];

--- a/config/alt-redirect.php
+++ b/config/alt-redirect.php
@@ -7,7 +7,7 @@ return [
     | Headers
     |--------------------------------------------------------------------------
     |
-    | A key/value pair of Headers to be included with the redirect. This
+    | A key/value pair array of Headers to be included with the redirect. This
     | applies to all redirects. For example:
     |
     | 'headers' => [

--- a/src/Http/Middleware/CheckForRedirects.php
+++ b/src/Http/Middleware/CheckForRedirects.php
@@ -43,7 +43,7 @@ class CheckForRedirects
                     return $next($request);
                 }
                 if (!($redirect['sites'] ?? false) || (in_array(Site::current(), $redirect['sites']))) {
-                    return redirect($to , $redirect['redirect_type'] ?? 301);
+                    return redirect($to , $redirect['redirect_type'] ?? 301, config('alt-redirect.headers', []));
                 }
             }
         }
@@ -54,7 +54,7 @@ class CheckForRedirects
             if (preg_match('#' . $redirect['from'] . '#', $uri)) {
                 $redirectTo = preg_replace('#' . $redirect['from'] . '#', $redirect['to'], $uri);
                 if (!($redirect['sites'] ?? false) || (in_array(Site::current(), $redirect['sites']))) {
-                    return redirect($redirectTo ?? '/', $redirect['redirect_type'] ?? 301);
+                    return redirect($redirectTo ?? '/', $redirect['redirect_type'] ?? 301, config('alt-redirect.headers', []));
                 }
             }
         }


### PR DESCRIPTION
Addresses https://github.com/alt-design/Alt-Redirect-Addon/issues/12

Adds a new (optional) config file that can take an array of headers to be passed to the `redirect`.

By default there is no change to behaviour. Headers must be explicitly added in a site's config to make use of this.

You can run `php artisan vendor:publish` and browse to the Alt Redirect service provider, or run:
```bash
php artisan vendor:publish --tag=alt-redirect-config
```