### PR TITLE
fix import Data instantiation

### DIFF
--- a/src/Http/Controllers/AltRedirectController.php
+++ b/src/Http/Controllers/AltRedirectController.php
@@ -189,7 +189,7 @@ class AltRedirectController
             // Close the file handle
             fclose($handle);
         }
-        $data = new Data('redirect');
+        $data = new Data('redirects');
         $data->saveAll($currentData);
 
     }


### PR DESCRIPTION
Closes #26

Fixes small typo that was instantiating `Data` with an invalid type in the `AltRedirectController.import()` method.