### PR TITLE
alt-redirect.php - added 'disable-enhanced-multisite' key to flag whe…

### DIFF
--- a/config/alt-redirect.php
+++ b/config/alt-redirect.php
@@ -16,6 +16,7 @@ return [
     |
     */
 
-    'headers' => []
+    'headers' => [],
 
+    'disable-enhanced-multisite' => (bool) env('ALT_REDIRECT_DISABLE_ENHANCED_MULTISITE', false),
 ];

--- a/src/Helpers/URISupport.php
+++ b/src/Helpers/URISupport.php
@@ -6,6 +6,7 @@ namespace AltDesign\AltRedirect\Helpers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Statamic\Facades\Site;
 
 class URISupport
 {
@@ -60,5 +61,27 @@ class URISupport
     private static function myArrQuery(array $array, $encoding_type = PHP_QUERY_RFC1738) : string
     {
         return http_build_query($array, '', '&', $encoding_type);
+    }
+
+    /**
+     * Use the Statamic site facade to determine the current site and strip off the
+     * part of the URI for the site.
+     *
+     * @param string $fullUri
+     * @return string
+     */
+    public static function filterSubsiteUri(string $fullUri) : string
+    {
+        $subSiteURI = Site::current()->url();
+
+        if ($subSiteURI == '/') {
+            return $fullUri;
+        }
+
+        return Str::replaceFirst(
+            $subSiteURI,
+            '',
+            $fullUri
+        );
     }
 }


### PR DESCRIPTION
…ther the enhanced multisite support is disabled.

URISupport.php - Added a function to filter the site URL off the URIs, EG "/fr" subsite would be filtered from "/fr/page" to "/page" before redirect being checked.

CheckForRedirects.php - Added in optional subsite URI filtering based on config. Added in optional augmentation of the redirect URI, if enabled the redirect URL has the subsite url prepended in.

Full flow EG :

"/fr/old" has it's subsite URI stripped to "/old"

Redirect is processed like normal, EG: "/old" -> "/new"

then on the way out "/new" has the site prepended to "/fr/new" and this is used in the redirect.